### PR TITLE
fix: correct the return value of putXXXs

### DIFF
--- a/secure-shared-preferences/src/main/java/com/github/ibara1454/secure_shared_preferences/shared_preferences/EncryptableSharedPreferences.kt
+++ b/secure-shared-preferences/src/main/java/com/github/ibara1454/secure_shared_preferences/shared_preferences/EncryptableSharedPreferences.kt
@@ -253,7 +253,8 @@ internal class EncryptableSharedPreferences(
          * will be any that you have defined in this editor.
          */
         override fun clear(): SharedPreferences.Editor {
-            return editor.clear()
+            editor.clear()
+            return this
         }
 
         /**
@@ -276,10 +277,11 @@ internal class EncryptableSharedPreferences(
          * chain put calls together.
          */
         override fun putBoolean(key: String?, value: Boolean): SharedPreferences.Editor {
-            return editor.putString(
+            editor.putString(
                 key?.let { pnEncrypt("boolean_$key") } ,
                 value.toString().let(pvEncrypt)
             )
+            return this
         }
 
         /**
@@ -294,10 +296,11 @@ internal class EncryptableSharedPreferences(
          */
         override fun putFloat(key: String?, value: Float): SharedPreferences.Editor {
             // TODO: use scientific notation to convert to string instead
-            return editor.putString(
+            editor.putString(
                 key?.let { pnEncrypt("float_$key") } ,
                 value.toString().let(pvEncrypt)
             )
+            return this
         }
 
         /**
@@ -310,10 +313,11 @@ internal class EncryptableSharedPreferences(
          *  chain put calls together.
          */
         override fun putInt(key: String?, value: Int): SharedPreferences.Editor {
-            return editor.putString(
+            editor.putString(
                 key?.let { pnEncrypt("int_$key") } ,
                 value.toString().let(pvEncrypt)
             )
+            return this
         }
 
         /**
@@ -326,10 +330,11 @@ internal class EncryptableSharedPreferences(
          *  chain put calls together.
          */
         override fun putLong(key: String?, value: Long): SharedPreferences.Editor {
-            return editor.putString(
+            editor.putString(
                 key?.let { pnEncrypt("long_$key") } ,
                 value.toString().let(pvEncrypt)
             )
+            return this
         }
 
         /**
@@ -344,10 +349,11 @@ internal class EncryptableSharedPreferences(
          *  chain put calls together.
          */
         override fun putString(key: String?, value: String?): SharedPreferences.Editor {
-            return editor.putString(
+            editor.putString(
                 key?.let { pnEncrypt("string_$key") } ,
                 value?.let(pvEncrypt)
             )
+            return this
         }
 
         /**
@@ -366,10 +372,11 @@ internal class EncryptableSharedPreferences(
             // An random generate string.
             // The random string is complex enough so it would not disturb the given data.
             val separator = "8u^K>LK*O4"
-            return editor.putString(
+            editor.putString(
                 key?.let { pnEncrypt("stringset_$key") } ,
                 values?.joinToString(separator)?.let(pvEncrypt)
             )
+            return this
         }
 
         /**
@@ -389,7 +396,7 @@ internal class EncryptableSharedPreferences(
                     .map { "${it}_${key}" }
                     .forEach { editor.remove(pnEncrypt(it)) }
             }
-            return editor
+            return this
         }
     }
 }

--- a/secure-shared-preferences/src/test/java/com/github/ibara1454/secure_shared_preferences/shared_preferences/EncryptableSharedPreferencesTest.kt
+++ b/secure-shared-preferences/src/test/java/com/github/ibara1454/secure_shared_preferences/shared_preferences/EncryptableSharedPreferencesTest.kt
@@ -412,7 +412,9 @@ class EditorImplTest {
         every { nativeEditor.clear() } returns nativeEditor
 
         val editor = EncryptableSharedPreferences.EditorImpl(nativeEditor, prefNameEncrypter, prefValueEncrypter)
-        editor.clear()
+        val actual = editor.clear()
+
+        assertThat(actual).isEqualTo(editor)
 
         verify(exactly = 1) { nativeEditor.clear() }
     }
@@ -445,7 +447,9 @@ class EditorImplTest {
         every { nativeEditor.putString(any(), any()) } returns nativeEditor
 
         val editor = EncryptableSharedPreferences.EditorImpl(nativeEditor, prefNameEncrypter, prefValueEncrypter)
-        editor.putBoolean("name", true)
+        val actual = editor.putBoolean("name", true)
+
+        assertThat(actual).isEqualTo(editor)
 
         verifyAll {
             prefNameEncrypter.encrypt("boolean_name")
@@ -466,7 +470,9 @@ class EditorImplTest {
         every { nativeEditor.putString(any(), any()) } returns nativeEditor
 
         val editor = EncryptableSharedPreferences.EditorImpl(nativeEditor, prefNameEncrypter, prefValueEncrypter)
-        editor.putFloat("name", 1.0f)
+        val actual = editor.putFloat("name", 1.0f)
+
+        assertThat(actual).isEqualTo(editor)
 
         verifyAll {
             prefNameEncrypter.encrypt("float_name")
@@ -487,7 +493,9 @@ class EditorImplTest {
         every { nativeEditor.putString(any(), any()) } returns nativeEditor
 
         val editor = EncryptableSharedPreferences.EditorImpl(nativeEditor, prefNameEncrypter, prefValueEncrypter)
-        editor.putInt("name", 1)
+        val actual = editor.putInt("name", 1)
+
+        assertThat(actual).isEqualTo(editor)
 
         verifyAll {
             prefNameEncrypter.encrypt("int_name")
@@ -508,7 +516,9 @@ class EditorImplTest {
         every { nativeEditor.putString(any(), any()) } returns nativeEditor
 
         val editor = EncryptableSharedPreferences.EditorImpl(nativeEditor, prefNameEncrypter, prefValueEncrypter)
-        editor.putLong("name", 1L)
+        val actual = editor.putLong("name", 1L)
+
+        assertThat(actual).isEqualTo(editor)
 
         verifyAll {
             prefNameEncrypter.encrypt("long_name")
@@ -529,7 +539,9 @@ class EditorImplTest {
         every { nativeEditor.putString(any(), any()) } returns nativeEditor
 
         val editor = EncryptableSharedPreferences.EditorImpl(nativeEditor, prefNameEncrypter, prefValueEncrypter)
-        editor.putString("name", "value")
+        val actual = editor.putString("name", "value")
+
+        assertThat(actual).isEqualTo(editor)
 
         verifyAll {
             prefNameEncrypter.encrypt("string_name")
@@ -550,7 +562,9 @@ class EditorImplTest {
         every { nativeEditor.putString(any(), any()) } returns nativeEditor
 
         val editor = EncryptableSharedPreferences.EditorImpl(nativeEditor, prefNameEncrypter, prefValueEncrypter)
-        editor.putString("name", null)
+        val actual = editor.putString("name", null)
+
+        assertThat(actual).isEqualTo(editor)
 
         verifyAll {
             prefNameEncrypter.encrypt("string_name")
@@ -570,7 +584,9 @@ class EditorImplTest {
         every { nativeEditor.putString(any(), any()) } returns nativeEditor
 
         val editor = EncryptableSharedPreferences.EditorImpl(nativeEditor, prefNameEncrypter, prefValueEncrypter)
-        editor.putStringSet("name", mutableSetOf("1", "2", "3"))
+        val actual = editor.putStringSet("name", mutableSetOf("1", "2", "3"))
+
+        assertThat(actual).isEqualTo(editor)
 
         verifyAll {
             prefNameEncrypter.encrypt("stringset_name")
@@ -591,7 +607,9 @@ class EditorImplTest {
         every { nativeEditor.putString(any(), any()) } returns nativeEditor
 
         val editor = EncryptableSharedPreferences.EditorImpl(nativeEditor, prefNameEncrypter, prefValueEncrypter)
-        editor.putStringSet("name", mutableSetOf())
+        val actual = editor.putStringSet("name", mutableSetOf())
+
+        assertThat(actual).isEqualTo(editor)
 
         verifyAll {
             prefNameEncrypter.encrypt("stringset_name")
@@ -612,7 +630,9 @@ class EditorImplTest {
         every { nativeEditor.putString(any(), any()) } returns nativeEditor
 
         val editor = EncryptableSharedPreferences.EditorImpl(nativeEditor, prefNameEncrypter, prefValueEncrypter)
-        editor.putStringSet("name", null)
+        val actual = editor.putStringSet("name", null)
+
+        assertThat(actual).isEqualTo(editor)
 
         verifyAll {
             prefNameEncrypter.encrypt("stringset_name")
@@ -633,7 +653,9 @@ class EditorImplTest {
 
         val name = "name"
         val editor = EncryptableSharedPreferences.EditorImpl(nativeEditor, prefNameEncrypter, prefValueEncrypter)
-        editor.remove(name)
+        val actual = editor.remove(name)
+
+        assertThat(actual).isEqualTo(editor)
 
         verify {
             nativeEditor.remove("encrypted_boolean_name")


### PR DESCRIPTION
## Proposed Changes

- Fix the bug that EditorImpl#putXXXX methods return the native editor

## Details

There are two editors could returned from EditorImpl#putXXXX:
- EditorImpl it self.
- Native SharedPreferences#Editor.

The bug is that EditorImpl#putXXXX returns the native editor so that the chained call

```kotlin
val editor = preferences.edit()  // Encrypted editor
edit.putString("key1", "value1")  // Call putString on encrypted editor, but this call returns the native one.
    .putString("key2", "value2")  // Call putString on native editor. This may leads to crash.
    .apply()
```

may cause a crash.

So this PR fix the bugs and make unit test to ensure that putXXX returns the encrypted editor.